### PR TITLE
Some improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,28 @@ Usage of inch:
     	Batch size (default 5000)
   -c int
     	Concurrency (default 1)
+  -consistency string
+    	Write consistency (default any) (default "any")
+  -db string
+    	Database to write to (default "stress")
+  -delay duration
+    	Delay between writes
+  -dry
+    	Dry run (maximum writer perf of inch on box)
+  -f int
+    	Fields per point (default 1)
   -host string
     	Host (default "http://localhost:8086")
+  -m int
+    	Measurements (default 1)
   -p int
     	Points per series (default 100)
+  -strict
+    	Terminate process if error encountered
   -t string
     	Tag cardinality (default "10,10,10")
+  -time duration
+    	Time span to spread writes over
   -v	Verbose
 ```
 

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ type Main struct {
 
 	Database string
 	TimeSpan time.Duration // The length of time to span writes over.
+	Delay    time.Duration // A delay inserted in between writes.
 }
 
 // NewMain returns a new instance of Main.
@@ -84,6 +85,7 @@ func (m *Main) ParseFlags(args []string) error {
 	fs.IntVar(&m.BatchSize, "b", 5000, "Batch size")
 	fs.StringVar(&m.Database, "db", "stress", "Database to write to")
 	fs.DurationVar(&m.TimeSpan, "time", 0, "Time span to spread writes over")
+	fs.DurationVar(&m.Delay, "delay", 0, "Delay between writes")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -130,6 +132,7 @@ func (m *Main) Run() error {
 	fmt.Fprintf(m.Stdout, "Batch Size: %d\n", m.BatchSize)
 	fmt.Fprintf(m.Stdout, "Database: %s\n", m.Database)
 	fmt.Fprintf(m.Stdout, "Write Consistency: %s\n", m.Consistency)
+	fmt.Fprintf(m.Stdout, "Write Delay: %s\n", m.Delay)
 
 	dur := fmt.Sprint(m.TimeSpan)
 	if m.TimeSpan == 0 {
@@ -380,6 +383,9 @@ func (m *Main) sendBatch(buf []byte) error {
 		return fmt.Errorf("[%d] %s", resp.StatusCode, body)
 	}
 
+	if m.Delay > 0 {
+		time.Sleep(m.Delay)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR adds some improvements to `inch` that I've found useful recently:


 - `dry-run` mode. This builds all the points and then discards them rather than sending them over the wire. It gives you a rough idea of the maximum throughput `inch` can produce on your client box.
 - `strict` mode. Strict mode being on will result in `inch` exiting if a non `204` response is returned from the server.
 - `consistency`. Set the desired write consistency.
 - `delay`. Setting a delay allows you to reduce the throughput from `inch` by waiting before a writer sends the next batch.
 - Historical mode. By setting a negative `-time` duration you can write historical data. For example `-time -168h` will write points starting 7 days ago and ending now. 