### PR TITLE
Automatic backoff (adaptive write delay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Usage of inch:
     	Terminate process if error encountered
   -t string
     	Tag cardinality (default "10,10,10")
+  -target-latency duration
+      If set inch will attempt to adapt write delay to meet target
   -time duration
     	Time span to spread writes over
   -v	Verbose
@@ -58,4 +60,13 @@ each combination of these values so the total number of series can be computed
 by multiplying the values (`100 * 20 * 4`).
 
 By setting the `verbose` flag you can see progress each second.
+
+The `-target-latency` flag will allow `inch` to automatically backoff (add 
+delays after writing batches) according to the weighted moving average of 
+response times from the InfluxDB server. If the WMA of responses is greater than 
+the target latency then delays will be increased in an attempt to allow the 
+InfluxDB server time to recover and process in-flight writes. If a delay is in 
+place on `inch` clients yet the WMA of response times is lower than the target
+latency, then `inch` will reduce the delays in an attempt to increase throughput.
+
 


### PR DESCRIPTION
This PR adds the ability to use a rudimentary adaptive write delay
when writing data with inch.

If the `-target-latency` flag is set, then `inch` will attempt to
increase writers' delays when the server responses take longer than
`target-latency`, and reduce the writers' delays when they're quicker
than `target-latency`.

In an attempt to smooth the adjustments, `inch` tracks the weight moving average response
from all the writers, and updates it weighting the most recent response 50%, and the historic average response 50%.

In general, when updating the write delay, `inch` adapts the current delay proportionally to the number of concurrent writers and the size of the difference between the WMA
response time and the desired maximum time (target latency).

Currently `inch` changes the delay by 50% of the difference between the WMA and the target latency. 