### PR TITLE
Add remote reporting of inch results

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,16 @@ Usage of inch:
     	Measurements (default 1)
   -p int
     	Points per series (default 100)
+  -report-host string
+    	Host to send metrics
+  -report-tags string
+    	Comma separated k=v tags to report alongside metrics
   -strict
     	Terminate process if error encountered
   -t string
     	Tag cardinality (default "10,10,10")
   -target-latency duration
-      If set inch will attempt to adapt write delay to meet target
+    	If set inch will attempt to adapt write delay to meet target
   -time duration
     	Time span to spread writes over
   -v	Verbose
@@ -68,5 +72,15 @@ the target latency then delays will be increased in an attempt to allow the
 InfluxDB server time to recover and process in-flight writes. If a delay is in 
 place on `inch` clients yet the WMA of response times is lower than the target
 latency, then `inch` will reduce the delays in an attempt to increase throughput.
+
+The `-report-host` flag can be used to specify the location of an InfluxDB 
+instance, to be used for reporting the results of inch. A local instance to inch
+would be specified as `-report-host http://localhost:8086`. Inch will provide 
+appropriate tags where possible, but arbitrary tags can be set using the 
+`-report-tags` flag. The format for `-report-tags` is a comma separated list of 
+key value pairs. For example `-report-tags instance=m4.2xlarge,index=tsi1`.
+
+When `-report-host` is set to a non-empty value, inch will report throughput, 
+points and values written, as well as write latency statistics.
 
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Usage of inch:
     	Host to send metrics
   -report-tags string
     	Comma separated k=v tags to report alongside metrics
+  -shard-duration string
+    	Set shard duration (default 7d)
   -strict
     	Terminate process if error encountered
   -t string

--- a/main.go
+++ b/main.go
@@ -376,8 +376,9 @@ type Stats struct {
 	Fields models.Fields
 }
 
-func (m *Main) GatherStats() *Stats {
+func (m *Main) Stats() *Stats {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	elapsed := time.Since(m.now).Seconds()
 	pThrough := float64(m.writtenN) / elapsed
 	s := &Stats{
@@ -406,7 +407,6 @@ func (m *Main) GatherStats() *Stats {
 
 	// Reset error count for next reporting.
 	m.currentErrors = 0
-	m.mu.Unlock()
 	return s
 }
 
@@ -430,7 +430,7 @@ func (m *Main) runMonitor(ctx context.Context) {
 }
 
 func (m *Main) sendMonitorStats() {
-	stats := m.GatherStats()
+	stats := m.Stats()
 	bp, err := client.NewBatchPoints(client.BatchPointsConfig{
 		Database: m.Database,
 	})


### PR DESCRIPTION
This PR adds remote reporting of `inch` results. Results will be reported every second.

To use this feature provide the `-report-host http://ip:port` flag, specifying the host of an InfluxDB instance, along with the port that accepts writes over HTTP.

`inch` will report the following fields every second:

 - values written
 - points written
 - value throughput
 - point throughput
 - mean write response latency
 - WMA write response latency
 - 90th percentile response latency
 - 95th percentile response latency
 - 99th percentile response latency
 - Number of write errors in the last second

By default, `inch` will associate the following tags with each point submitted:

  - `stress_tool = inch`
  - `t = <value of -t flag>`
  - `batch_size = <batch size>`
  - `p = <points per series>`
  - `c = <concurrency>`
  - `m = <number of measurements to be written>`
  - `f = <number of fields per point>`
  - `sd = <value of -shard-duration flag>`

Further, the operator can provide the `-report-tags` to specify arbitrary tags that should also be associated with each point. The value for `-report-tags` should be a comma-separated list of `key=value` pairs. For example: `-report-tags instance="m4.2xlarge,test_name=my test"`

Finally, this PR adds a `-shard-duration` flag that allows the operator to specify the shard duration of the retention policy receiving the stress data.